### PR TITLE
Move ordering, small changes

### DIFF
--- a/Globals.cs
+++ b/Globals.cs
@@ -13,6 +13,8 @@ using static ChessBot.Program;
 
 //Why doesn't engine take c3? 2r1kr2/ppp1np2/4p3/3pP2Q/b2P2B1/1PP5/P7/2KRq1NR b - - 4 25
 
+//position fen r1bqkb1r/ppp2ppp/2np1n2/4p3/2B1P3/2NP1N2/PPP2PPP/R1BQK2R b KQkq - 0 5 //early game pos
+
 //0b_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000;
 class Globals
 {
@@ -273,4 +275,7 @@ class Globals
     public static bool stopSearch = false;
 
     public static int qDepth = 6;
+
+    public static int totalNodes;
+    public static int currNodes;
 }

--- a/Program.cs
+++ b/Program.cs
@@ -181,6 +181,9 @@ namespace ChessBot
                         Move bestMove = null;
                         int eval = 0;
                         int depth;
+                        int bestVal = 0;
+                        int currVal = 0;
+                        totalNodes = 0;
                         stopSearch = false;
                         //stop searching after estimated time
                         Task.Factory.StartNew(() => Thread.Sleep((int)(time * 1000)))
@@ -188,9 +191,9 @@ namespace ChessBot
                         {
                             stopSearch = true;
                         });
-                        for (depth = 0; depth < 21; depth++)
+                        currNodes = 0;
+                        for (depth = 0; depth < 8; depth++)
                         {
-
                             Move currBest = new Move();
                             List<Move> moves = new List<Move>();
                             if (color == 'b') //minimizing
@@ -269,11 +272,13 @@ namespace ChessBot
                                             currBest = moves[i];
                                             minEval = Math.Min(temp, minEval);
                                             eval = minEval;
+                                            currVal = temp;
                                         }
                                         //blackTable[newHash] = new Entry(minEval, depth, null, age);
                                     }
                                     Board.makeBoards(ref bPawn, ref bRook, ref bKnight, ref bBishop, ref bQueen, ref bKing, ref wPawn, ref wRook, ref wKnight, ref wBishop,
                                         ref wQueen, ref wKing, ref allPieces, ref empty, board, ref whitePieces, ref blackPieces);
+                                    currNodes++;
                                 }
                                 //Console.WriteLine(minEval);
                                 blackTable[currH] = new Entry(minEval, depth, currBest, age);
@@ -356,11 +361,13 @@ namespace ChessBot
                                             currBest = moves[i];
                                             maxEval = Math.Max(temp, maxEval);
                                             eval = maxEval;
+                                            currVal = temp;
                                         }
                                         //whiteTable[newHash] = new Entry(temp, depth, null, age);
                                     }
                                     Board.makeBoards(ref bPawn, ref bRook, ref bKnight, ref bBishop, ref bQueen, ref bKing, ref wPawn, ref wRook, ref wKnight, ref wBishop,
                                         ref wQueen, ref wKing, ref allPieces, ref empty, board, ref whitePieces, ref blackPieces);
+                                    currNodes++;
                                 }
                                 whiteTable[currH] = new Entry(maxEval, depth, currBest, age);
                             }
@@ -368,7 +375,9 @@ namespace ChessBot
                             {
                                 break;
                             }
+                            totalNodes += currNodes;
                             bestMove = currBest;
+                            bestVal = currVal;
                             age++;
                             //Array.Clear(killers, 0, killers.Length);
                             //Console.WriteLine(notation[currBest.source] + notation[currBest.dest]);
@@ -388,7 +397,7 @@ namespace ChessBot
                             Console.WriteLine("bestmove " + notation[bestMove.source] + notation[bestMove.dest]);
                         }
                         timer.Stop();
-                        Console.WriteLine("Elapsed time: " + timer.Elapsed.ToString() + " Interrupted Depth: " + depth);
+                        Console.WriteLine("Elapsed time: " + timer.Elapsed.ToString() + " Interrupted Depth: " + depth + " Nodes: " + currNodes + " Eval: " + bestVal);
                         //Console.WriteLine("Alloted time: " + time + " Interrupted Depth: " + depth);
                         //Console.WriteLine("Seconds elapsed: " + timer.Elapsed.Seconds.ToString() + " Depth: " + depth);
                         timer.Reset();


### PR DESCRIPTION
- Changed move ordering so killer moves always go after even/favorable captures. Followed by Unfavorable captures. Moves much faster however can produce different moves.

-Example:
BEFORE CHANGE
position startpos moves d2d4 e7e6 g1f3 b8c6 c1f4 d7d5 e2e3 f8b4 c2c3 b4e7 f1d3 h7h6 go
bestmove d3b5
Elapsed time: 00:00:15.0006475 Interrupted Depth: 8 Nodes: 19654104 Eval: 30

AFTER CHANGE
position startpos moves d2d4 e7e6 g1f3 b8c6 c1f4 d7d5 e2e3 f8b4 c2c3 b4e7 f1d3 h7h6 go
bestmove f3e5
Elapsed time: 00:00:05.7216221 Interrupted Depth: 8 Nodes: 6275610 Eval: 5

Can move ordering change the best move?